### PR TITLE
Stop teaching about UndoList.Msg type in docs

### DIFF
--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -1,65 +1,61 @@
-module Main exposing (..)
+module Counter exposing (..)
 
 import Html exposing (..)
 import Html.App as Html
 import Html.Events exposing (onClick)
-import UndoList as UL exposing (UndoList, Msg(..))
+import UndoList exposing (UndoList)
+import Html exposing (div, button, text)
+import Html.Events exposing (onClick)
+import Html.App as Html
+import UndoList exposing (UndoList)
 
 
--------------------------------
--- Version with undo support --
--------------------------------
-
-
-init =
-    0
-
-
-update _ state =
-    state + 1
-
-
-view state =
-    div []
-        [ button [ onClick (New ()) ] [ text "Increment" ]
-        , button [ onClick Undo ] [ text "Undo" ]
-        , button [ onClick Redo ] [ text "Redo" ]
-        , div [] [ text (toString state) ]
-        ]
-
-
+main : Program Never
 main =
     Html.beginnerProgram
-        { model = UL.fresh init
-        , update = UL.update update
-        , view = UL.view view
-        }
-
-
-
-----------------------------------
--- Version without undo support --
-----------------------------------
-{--
-init =
-    0
-
-
-update _ state =
-    state + 1
-
-
-view state =
-    div []
-        [ button [ onClick () ] [ text "Increment" ]
-        , div [] [ text (toString state) ]
-        ]
-
-
-main =
-    Html.beginnerProgram
-        { model = init
-        , update = update
+        { model = UndoList.fresh 0
         , view = view
+        , update = update
         }
---}
+
+
+type alias Model =
+    UndoList Int
+
+
+type Msg
+    = Increment
+    | Undo
+    | Redo
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        Increment ->
+            UndoList.new (model.present + 1) model
+
+        Undo ->
+            UndoList.undo model
+
+        Redo ->
+            UndoList.redo model
+
+
+view : Model -> Html Msg
+view model =
+    div
+        []
+        [ button
+            [ onClick Increment ]
+            [ text "Increment" ]
+        , button
+            [ onClick Undo ]
+            [ text "Undo" ]
+        , button
+            [ onClick Redo ]
+            [ text "Redo" ]
+        , div
+            []
+            [ text (toString model) ]
+        ]

--- a/examples/CounterWithCats.elm
+++ b/examples/CounterWithCats.elm
@@ -1,0 +1,119 @@
+module CounterWithCats exposing (..)
+
+import Html exposing (..)
+import Html.App as Html
+import Html.Attributes exposing (src)
+import Html.Events exposing (onClick)
+import UndoList exposing (UndoList)
+import Html exposing (div, button, text)
+import Html.Events exposing (onClick)
+import Html.App as Html
+import UndoList exposing (UndoList)
+import Http
+import Task
+import Json.Decode as Json
+
+
+main : Program Never
+main =
+    Html.program
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = always Sub.none
+        }
+
+
+type alias Model =
+    UndoList
+        { counter : Int
+        , gifUrl : Maybe String
+        }
+
+
+type Msg
+    = Increment
+    | Undo
+    | Redo
+    | FetchSucceed String
+    | FetchFail Http.Error
+
+
+init : ( Model, Cmd msg )
+init =
+    ( UndoList.fresh { counter = 0, gifUrl = Nothing }
+    , Cmd.none
+    )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg ({ present } as model) =
+    case msg of
+        Increment ->
+            ( UndoList.new
+                { present | counter = present.counter + 1 }
+                model
+            , getRandomGif "cats"
+            )
+
+        Undo ->
+            ( UndoList.undo model, Cmd.none )
+
+        Redo ->
+            ( UndoList.redo model, Cmd.none )
+
+        FetchSucceed newUrl ->
+            ( UndoList.mapPresent
+                (\present -> { present | gifUrl = Just newUrl })
+                model
+            , Cmd.none
+            )
+
+        FetchFail _ ->
+            ( model, Cmd.none )
+
+
+view : Model -> Html Msg
+view model =
+    div
+        []
+        [ button
+            [ onClick Increment ]
+            [ text "Increment" ]
+        , button
+            [ onClick Undo ]
+            [ text "Undo" ]
+        , button
+            [ onClick Redo ]
+            [ text "Redo" ]
+        , div
+            []
+            [ text (toString model.present.counter) ]
+        , div
+            []
+            (case model.present.gifUrl of
+                Just gifUrl ->
+                    [ img [ src gifUrl ] [] ]
+
+                Nothing ->
+                    [ text "Increment to display a GIF image" ]
+            )
+        ]
+
+
+
+-- Taken from https://guide.elm-lang.org/architecture/effects/http.html
+
+
+getRandomGif : String -> Cmd Msg
+getRandomGif topic =
+    let
+        url =
+            "https://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=" ++ topic
+    in
+        Task.perform FetchFail FetchSucceed (Http.get decodeGifUrl url)
+
+
+decodeGifUrl : Json.Decoder String
+decodeGifUrl =
+    Json.at [ "data", "image_url" ] Json.string

--- a/examples/TextEditor.elm
+++ b/examples/TextEditor.elm
@@ -1,28 +1,77 @@
-module Main exposing (..)
+module TextEditor exposing (..)
 
 import Html exposing (Html)
 import Html.App as Html
 import Html.Events exposing (onInput, onClick)
 import Html.Attributes exposing (style, value, placeholder)
-import UndoList as UL exposing (Msg(..), UndoList)
+import UndoList exposing (UndoList)
+
+
+-- Main
+
+
+main : Program Never
+main =
+    Html.beginnerProgram
+        { model = init
+        , update = update
+        , view = view
+        }
+
+
+
+-- Model
+
+
+type alias Model =
+    UndoList { content : String }
+
+
+init : Model
+init =
+    UndoList.fresh { content = "" }
+
+
+
+-- Update
+
+
+type Msg
+    = UpdateContent String
+    | Undo
+    | Redo
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        UpdateContent str ->
+            UndoList.new { content = str } model
+
+        Undo ->
+            UndoList.undo model
+
+        Redo ->
+            UndoList.redo model
+
 
 
 -- View
 
 
-view : Model -> Html (UL.Msg Msg)
+view : Model -> Html Msg
 view model =
     let
-        button value =
+        button msg =
             Html.button
-                [ onClick value
+                [ onClick msg
                 , style
                     [ "width" => "8em"
                     , "height" => "3em"
                     , "font-size" => "14pt"
                     ]
                 ]
-                [ Html.text <| toString value ]
+                [ Html.text <| toString msg ]
 
         undoButton =
             button Undo
@@ -51,8 +100,8 @@ view model =
 
         textArea =
             Html.textarea
-                [ onInput (New << UpdateContent)
-                , value model.content
+                [ onInput UpdateContent
+                , value model.present.content
                 , placeholder "Enter text here..."
                 , style
                     [ "flex" => "1"
@@ -77,51 +126,6 @@ view model =
             [ headerArea
             , textArea
             ]
-
-
-
--- Model
-
-
-type alias Model =
-    { content : String }
-
-
-
--- The initial state of the entire application
-
-
-init : Model
-init =
-    { content = "" }
-
-
-
--- Update
-
-
-type Msg
-    = UpdateContent String
-
-
-update : Msg -> Model -> Model
-update msg model =
-    case msg of
-        UpdateContent str ->
-            { content = str }
-
-
-
--- Main
-
-
-main : Program Never
-main =
-    Html.beginnerProgram
-        { model = UL.fresh init
-        , update = UL.update update
-        , view = UL.view view
-        }
 
 
 

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -12,7 +12,8 @@
         "elm-community/random-extra": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
Following #4, I updated the docs and added an example with `Cmd`.

Please tell me if the next step is to completely remove the wrapping of `update` and `view`, and `UndoList.Msg` type.

Since there is no code change I didn't bump the version number, is it right?

Thanks for your review!
