### PR TITLE
Add demos to gh-pages branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 elm-stuff
+examples/dist

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Since there is no mutation, there is no risk of things getting corrupted. Given
 immutability lets you do structural sharing within data structures, it also
 means these snapshots can be quite compact!
 
+## Example demos
+
+- https://elm-community.github.io/undo-redo/counter.html
+- https://elm-community.github.io/undo-redo/text-editor.html
+- https://elm-community.github.io/undo-redo/counter-with-cats.html
 
 ## How it works
 
@@ -149,3 +154,7 @@ This API is designed to work really nicely with
 [The Elm Architecture](http://guide.elm-lang.org/architecture/index.html).
 
 It has a lot more cool stuff, so read the [docs](http://package.elm-lang.org/packages/elm-community/undo-redo/latest).
+
+## Production
+
+To compile and deploy the examples to GitHub static pages in `gh-pages` branch, run `./examples/deploy.sh`.

--- a/examples/deploy.sh
+++ b/examples/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+pushd examples
+rm -rf dist
+elm-make Counter.elm --warn --output=dist/counter.html
+elm-make CounterWithCats.elm --warn --output=dist/counter-with-cats.html
+elm-make TextEditor.elm --warn --output=dist/text-editor.html
+cd dist
+git init
+git add .
+git commit -m "Deploy to Github Pages"
+git push --force git@github.com:cbenz/undo-redo.git master:gh-pages
+popd

--- a/examples/deploy.sh
+++ b/examples/deploy.sh
@@ -9,5 +9,5 @@ cd dist
 git init
 git add .
 git commit -m "Deploy to Github Pages"
-git push --force git@github.com:cbenz/undo-redo.git master:gh-pages
+git push --force git@github.com:elm-community/undo-redo.git master:gh-pages
 popd


### PR DESCRIPTION
If you configure the git repo to have static pages using `gh-pages` branch, like I did in my fork, we'll have demos for this repo.

Example with my fork:
- https://cbenz.github.io/undo-redo/counter.html
- https://cbenz.github.io/undo-redo/counter-with-cats.html
- https://cbenz.github.io/undo-redo/text-editor.html
