### PR TITLE
Fix 'fresh' example

### DIFF
--- a/src/UndoList.elm
+++ b/src/UndoList.elm
@@ -149,7 +149,7 @@ redo { past, present, future } =
 
 i.e.
 
-    fresh 0 (UndoList [ 3, 2, 1 ] 4 [ 5, 6 ])
+    fresh 0
     --> UndoList [] 0 [ ]
 
 -}


### PR DESCRIPTION
`fresh` only takes one argument, so the example doesn't type check.

```bash
undo-redo> elm-verify-examples src/UndoList.elm -r
-- TOO MANY ARGS - /home/jhrcek/Devel/github.com/elm-community/undo-redo/tests/VerifyExamples/UndoList/Fresh0.elm

The `fresh` function expects 1 argument, but it got 2 instead.

23|                 fresh 0 (UndoList [ 3, 2, 1 ] 4 [ 5, 6 ])
```

After this fix running elm-verify-examples (I used the latest version of elm-verify-examples 4.0.0) with all modules in src works fine.